### PR TITLE
feat: add Manufacturing module — 5 IA agents + SQL + routes

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ from routes_ import (
     pushNotification,
     loanProposals, loanOffers, stripe_payments,
     creditScore, walletBalance, automatedPayments, signatureUpload,
+    manufacturing,
 )
 
 app = FastAPI(
@@ -141,6 +142,7 @@ app.include_router(creditScore.router)
 app.include_router(walletBalance.router)
 app.include_router(automatedPayments.router)
 app.include_router(signatureUpload.router)
+app.include_router(manufacturing.router)
 
 # --------------------------------------------------
 # Local development only

--- a/modules/alertDispatcher.py
+++ b/modules/alertDispatcher.py
@@ -1,0 +1,170 @@
+"""
+AlertDispatcher Agent
+
+Fires Push / SMS / WhatsApp at the right manufacturing moments:
+
+  CYCLE_DONE      → Push to client: "Tu ropa está lista"
+                  → WhatsApp to client with ticket summary
+  ORDER_READY     → SMS + Push to staff
+  MAINTENANCE     → Push to manager when machine wear >= 85
+  LOW_SUPPLY      → Push to manager (triggered by caller, threshold configurable)
+  COST_ALERT      → Push to manager when margin < 0
+
+Reuses existing pushNotifications + whatsapp modules.
+"""
+
+from fastapi.responses import JSONResponse
+from databases import connection
+from modules.costEngine import _sp
+import json
+
+
+def _send_push(company_id: int, client_id: int | None, title: str, body: str, data: dict = None) -> dict:
+    payload = {
+        "pushNotifications": [{
+            "action":    1,
+            "companyId": company_id,
+            "clientId":  client_id,
+            "title":     title,
+            "body":      body,
+            "data":      json.dumps(data or {}),
+            "channel":   "manufacturing",
+        }]
+    }
+    return _sp("sp_pushNotifications", payload)
+
+
+def _send_whatsapp(phone: str, message: str) -> dict:
+    conn = None
+    try:
+        from databases import connection as _connection
+        conn = _connection()
+        cur = conn.cursor()
+        cur.execute(
+            "EXEC [dbo].[sp_whatsapp] @pjsonfile = %s",
+            (json.dumps({"whatsapp": [{"action": 1, "phone": phone, "message": message}]}),)
+        )
+        row = cur.fetchone()
+        conn.commit()
+        return json.loads(row[0]) if row and row[0] else {}
+    except Exception as e:
+        return {"error": str(e), "whatsapp": "skipped"}
+    finally:
+        if conn:
+            try: conn.close()
+            except: pass
+
+
+async def notify_cycle_done(payload: dict):
+    """
+    POST /manufacturing/alerts/cycle-done
+    Sends Push + optional WhatsApp when a wash cycle completes.
+
+    Body: { companyId, orderId, clientId, clientPhone?, machineName,
+            cycleType, ticketPrice, realCostTotal, margin }
+    """
+    company_id   = payload.get("companyId")
+    order_id     = payload.get("orderId")
+    client_id    = payload.get("clientId")
+    machine_name = payload.get("machineName", "Máquina")
+    cycle_type   = payload.get("cycleType", "")
+    ticket_price = payload.get("ticketPrice", 0)
+    phone        = payload.get("clientPhone")
+
+    push_result = _send_push(
+        company_id, client_id,
+        title="🧺 ¡Tu ropa está lista!",
+        body=f"{machine_name} terminó tu ciclo {cycle_type}. Puedes pasar a recogerla.",
+        data={"orderId": order_id, "type": "cycle_done"},
+    )
+
+    wa_result = {}
+    if phone:
+        msg = (
+            f"✅ *Tu ropa está lista*\n"
+            f"Máquina: {machine_name}\n"
+            f"Servicio: {cycle_type}\n"
+            f"Total: ${ticket_price:.2f} MXN\n"
+            f"¡Pasa a recogerla cuando gustes!"
+        )
+        wa_result = _send_whatsapp(phone, msg)
+
+    # Mark alert sent on order
+    _sp("sp_productionOrders", {"orders": [{"action": "alert_sent", "orderId": order_id}]})
+
+    return JSONResponse({"push": push_result, "whatsapp": wa_result, "alertSent": True})
+
+
+async def notify_maintenance_needed(payload: dict):
+    """
+    POST /manufacturing/alerts/maintenance
+    Sends Push to manager when machine wear >= threshold.
+
+    Body: { companyId, managerId, machineId, machineName, wearScore,
+            remainingCycles, recommendation }
+    """
+    company_id     = payload.get("companyId")
+    manager_id     = payload.get("managerId")
+    machine_name   = payload.get("machineName", "Máquina")
+    wear_score     = payload.get("wearScore", 0)
+    remaining      = payload.get("remainingCycles", 0)
+    recommendation = payload.get("recommendation", "")
+    urgent         = int(wear_score) >= 95
+
+    push_result = _send_push(
+        company_id, manager_id,
+        title=f"{'🚨 URGENTE' if urgent else '⚠️'} Mantenimiento: {machine_name}",
+        body=f"Desgaste {wear_score}%. {recommendation}",
+        data={"type": "maintenance", "machineId": payload.get("machineId"), "wearScore": wear_score},
+    )
+    return JSONResponse({"push": push_result, "urgent": urgent})
+
+
+async def notify_low_margin(payload: dict):
+    """
+    POST /manufacturing/alerts/low-margin
+    Sends Push to manager when an order closes with negative or thin margin.
+
+    Body: { companyId, managerId, orderId, cycleType, ticketPrice,
+            realCostTotal, margin, marginPct }
+    """
+    company_id  = payload.get("companyId")
+    manager_id  = payload.get("managerId")
+    order_id    = payload.get("orderId")
+    cycle_type  = payload.get("cycleType", "")
+    ticket_price = float(payload.get("ticketPrice", 0))
+    real_cost   = float(payload.get("realCostTotal", 0))
+    margin      = float(payload.get("margin", 0))
+    margin_pct  = float(payload.get("marginPct", 0))
+    is_loss     = margin < 0
+
+    push_result = _send_push(
+        company_id, manager_id,
+        title=f"{'❌ Venta con pérdida' if is_loss else '⚠️ Margen bajo'} — {cycle_type}",
+        body=(
+            f"Orden #{order_id}: precio ${ticket_price:.2f} vs costo ${real_cost:.2f} "
+            f"({'pérdida' if is_loss else 'margen'} {margin_pct:.1f}%)"
+        ),
+        data={"type": "low_margin", "orderId": order_id, "marginPct": margin_pct},
+    )
+    return JSONResponse({"push": push_result, "isLoss": is_loss})
+
+
+async def notify_low_supply(payload: dict):
+    """
+    POST /manufacturing/alerts/low-supply
+    Body: { companyId, managerId, supplyName, currentLevel, unit }
+    """
+    company_id   = payload.get("companyId")
+    manager_id   = payload.get("managerId")
+    supply_name  = payload.get("supplyName", "Insumo")
+    current      = payload.get("currentLevel", 0)
+    unit         = payload.get("unit", "kg")
+
+    push_result = _send_push(
+        company_id, manager_id,
+        title=f"⚠️ Insumo bajo: {supply_name}",
+        body=f"Quedan {current} {unit} de {supply_name}. Favor de reabastecer.",
+        data={"type": "low_supply", "supply": supply_name},
+    )
+    return JSONResponse({"push": push_result})

--- a/modules/costEngine.py
+++ b/modules/costEngine.py
@@ -1,0 +1,180 @@
+"""
+CostEngine Agent — Real Wash Cost Calculator
+
+Formula per cycle:
+  electricity  = machine.kwhPerCycle  × rates.electricityPerKwh
+  water        = machine.litersPerCycle × rates.waterPerLiter
+  detergent    = order.detergentGrams × rates.detergentPerGram
+  labor        = (order.actualMinutes or machine.cycleMinutes) / 60 × rates.laborPerHour
+  depreciation = machine.purchaseCost / machine.lifetimeCycles
+  subtotal     = electricity + water + detergent + labor + depreciation
+  overhead     = subtotal × (rates.overheadPct / 100)
+  real_cost    = subtotal + overhead
+
+  margin    = ticketPrice - real_cost
+  marginPct = (margin / ticketPrice) × 100   (0 if ticketPrice == 0)
+  suggestPrice = real_cost × (1 + rates.targetMarginPct / 100)
+"""
+
+from fastapi.responses import JSONResponse
+from databases import connection
+import json
+
+
+def _conn():
+    return connection()
+
+
+def _sp(proc: str, payload: dict):
+    conn = None
+    try:
+        conn = _conn()
+        cur = conn.cursor()
+        cur.execute(f"EXEC [dbo].[{proc}] @pjsonfile = %s", (json.dumps(payload),))
+        row = cur.fetchone()
+        conn.commit()
+        return json.loads(row[0]) if row and row[0] else {}
+    except Exception as e:
+        return {"error": str(e)}
+    finally:
+        if conn:
+            try: conn.close()
+            except: pass
+
+
+def _get_machine(machine_id: int) -> dict:
+    result = _sp("sp_machines", {"machines": [{"action": "one", "machineId": machine_id}]})
+    return result if result and "error" not in result else {}
+
+
+def _get_rates(company_id: int) -> dict:
+    result = _sp("sp_utilityRates", {"rates": [{"action": "get", "companyId": company_id}]})
+    return result if result and "error" not in result else {
+        "electricityPerKwh": 3.20,
+        "waterPerLiter": 0.015,
+        "detergentPerGram": 0.08,
+        "laborPerHour": 80.0,
+        "overheadPct": 15.0,
+        "targetMarginPct": 40.0,
+    }
+
+
+def compute_cycle_cost(
+    machine_id: int,
+    company_id: int,
+    detergent_grams: float,
+    actual_minutes: float | None,
+    ticket_price: float,
+) -> dict:
+    """
+    Pure cost calculation. Returns breakdown dict.
+    Does NOT write to DB — caller decides whether to persist.
+    """
+    machine = _get_machine(machine_id)
+    rates = _get_rates(company_id)
+
+    kwh = float(machine.get("kwhPerCycle", 0))
+    liters = float(machine.get("litersPerCycle", 0))
+    cycle_mins = float(actual_minutes or machine.get("cycleMinutes", 45))
+    purchase = float(machine.get("purchaseCost", 0))
+    lifetime = float(machine.get("lifetimeCycles", 5000)) or 5000
+
+    elec = kwh * float(rates.get("electricityPerKwh", 3.20))
+    water = liters * float(rates.get("waterPerLiter", 0.015))
+    det = float(detergent_grams) * float(rates.get("detergentPerGram", 0.08))
+    labor = (cycle_mins / 60.0) * float(rates.get("laborPerHour", 80.0))
+    depreciation = purchase / lifetime
+    subtotal = elec + water + det + labor + depreciation
+    overhead = subtotal * (float(rates.get("overheadPct", 15.0)) / 100.0)
+    real_cost = subtotal + overhead
+
+    margin = ticket_price - real_cost
+    margin_pct = (margin / ticket_price * 100) if ticket_price > 0 else 0
+    suggest_price = real_cost * (1 + float(rates.get("targetMarginPct", 40.0)) / 100.0)
+
+    return {
+        "realCostElec":         round(elec, 4),
+        "realCostWater":        round(water, 4),
+        "realCostDetergent":    round(det, 4),
+        "realCostLabor":        round(labor, 4),
+        "realCostDepreciation": round(depreciation, 4),
+        "realCostOverhead":     round(overhead, 4),
+        "realCostTotal":        round(real_cost, 4),
+        "ticketPrice":          ticket_price,
+        "margin":               round(margin, 4),
+        "marginPct":            round(margin_pct, 2),
+        "suggestedPrice":       round(suggest_price, 2),
+        "breakdown": {
+            "electricity":   f"{kwh} kWh × ${rates.get('electricityPerKwh')} = ${elec:.4f}",
+            "water":         f"{liters} L × ${rates.get('waterPerLiter')} = ${water:.4f}",
+            "detergent":     f"{detergent_grams}g × ${rates.get('detergentPerGram')} = ${det:.4f}",
+            "labor":         f"{cycle_mins:.0f} min × ${rates.get('laborPerHour')}/h = ${labor:.4f}",
+            "depreciation":  f"${purchase} ÷ {int(lifetime)} cycles = ${depreciation:.4f}",
+            "overhead":      f"{rates.get('overheadPct')}% of ${subtotal:.4f} = ${overhead:.4f}",
+        }
+    }
+
+
+async def calculate_cost(payload: dict):
+    """POST /manufacturing/cost-engine/calculate"""
+    machine_id = payload.get("machineId")
+    company_id = payload.get("companyId")
+    detergent_grams = float(payload.get("detergentGrams", 0))
+    actual_minutes = payload.get("actualMinutes")
+    ticket_price = float(payload.get("ticketPrice", 0))
+
+    if not machine_id or not company_id:
+        return JSONResponse({"error": "machineId and companyId required"}, 400)
+
+    result = compute_cycle_cost(machine_id, company_id, detergent_grams, actual_minutes, ticket_price)
+    return JSONResponse(result)
+
+
+async def complete_order(payload: dict):
+    """
+    POST /manufacturing/cost-engine/complete
+    Calculates real cost, saves to productionOrder, increments machine cycles.
+    """
+    order_id = payload.get("orderId")
+    machine_id = payload.get("machineId")
+    company_id = payload.get("companyId")
+    detergent_grams = float(payload.get("detergentGrams", 0))
+    actual_minutes = payload.get("actualMinutes")
+    ticket_price = float(payload.get("ticketPrice", 0))
+
+    if not all([order_id, machine_id, company_id]):
+        return JSONResponse({"error": "orderId, machineId, companyId required"}, 400)
+
+    cost = compute_cycle_cost(machine_id, company_id, detergent_grams, actual_minutes, ticket_price)
+
+    result = _sp("sp_productionOrders", {"orders": [{
+        "action":               "complete",
+        "orderId":              order_id,
+        "realCostElec":         cost["realCostElec"],
+        "realCostWater":        cost["realCostWater"],
+        "realCostDetergent":    cost["realCostDetergent"],
+        "realCostLabor":        cost["realCostLabor"],
+        "realCostDepreciation": cost["realCostDepreciation"],
+        "realCostOverhead":     cost["realCostOverhead"],
+        "realCostTotal":        cost["realCostTotal"],
+        "ticketPrice":          ticket_price,
+        "margin":               cost["margin"],
+        "marginPct":            cost["marginPct"],
+    }]})
+
+    return JSONResponse({**cost, **result})
+
+
+async def get_utility_rates(payload: dict):
+    """GET current utility rates for a company"""
+    company_id = payload.get("companyId")
+    if not company_id:
+        return JSONResponse({"error": "companyId required"}, 400)
+    rates = _get_rates(company_id)
+    return JSONResponse(rates)
+
+
+async def upsert_utility_rates(payload: dict):
+    """Save or update utility rates"""
+    result = _sp("sp_utilityRates", {"rates": [{"action": "upsert", **payload}]})
+    return JSONResponse(result)

--- a/modules/maintenancePredictor.py
+++ b/modules/maintenancePredictor.py
@@ -1,0 +1,139 @@
+"""
+MaintenancePredictor Agent
+
+Tracks machine wear and predicts when service is needed.
+
+Wear score (0–100):
+  base            = (cyclesSinceLastMaintenance / maintenanceEvery) × 70
+  lifetime_factor = (currentCycleCount / lifetimeCycles) × 30
+  wear_score      = min(100, base + lifetime_factor)
+
+When wear_score >= 85 → trigger maintenance alert
+When wear_score >= 95 → force machine to 'maintenance' status
+"""
+
+from fastapi.responses import JSONResponse
+from databases import connection
+from modules.costEngine import _sp
+import json
+import math
+
+
+def _compute_wear(
+    cycles_since_maintenance: int,
+    maintenance_every: int,
+    current_cycle_count: int,
+    lifetime_cycles: int,
+) -> int:
+    maintenance_every = maintenance_every or 200
+    lifetime_cycles = lifetime_cycles or 5000
+    base = (cycles_since_maintenance / maintenance_every) * 70
+    lifetime_factor = (current_cycle_count / lifetime_cycles) * 30
+    return min(100, math.floor(base + lifetime_factor))
+
+
+def _predict_remaining_cycles(
+    current_cycle_count: int,
+    last_maintenance_cycle: int,
+    maintenance_every: int,
+) -> int:
+    next_service = last_maintenance_cycle + maintenance_every
+    return max(0, next_service - current_cycle_count)
+
+
+async def analyze_machine(payload: dict):
+    """
+    POST /manufacturing/maintenance/analyze
+    Computes wear score for one machine, updates DB, returns prediction.
+    """
+    machine_id = payload.get("machineId")
+    company_id = payload.get("companyId")
+
+    if not machine_id or not company_id:
+        return JSONResponse({"error": "machineId and companyId required"}, 400)
+
+    machine = _sp("sp_machines", {"machines": [{"action": "one", "machineId": machine_id}]})
+    if not machine or "error" in machine:
+        return JSONResponse({"error": "Machine not found"}, 404)
+
+    current = int(machine.get("currentCycleCount", 0))
+    last_maint = int(machine.get("lastMaintenanceCycle", 0))
+    maint_every = int(machine.get("maintenanceEvery", 200))
+    lifetime = int(machine.get("lifetimeCycles", 5000))
+    cycles_since = current - last_maint
+
+    wear = _compute_wear(cycles_since, maint_every, current, lifetime)
+    remaining = _predict_remaining_cycles(current, last_maint, maint_every)
+
+    needs_maintenance = wear >= 85
+    force_maintenance = wear >= 95
+
+    new_status = None
+    if force_maintenance and machine.get("status") == "available":
+        new_status = "maintenance"
+
+    _sp("sp_machines", {"machines": [{
+        "action":    "update",
+        "machineId": machine_id,
+        "wearScore": wear,
+        **({"status": new_status} if new_status else {}),
+    }]})
+
+    return JSONResponse({
+        "machineId":           machine_id,
+        "machineName":         machine.get("name"),
+        "currentCycleCount":   current,
+        "cyclesSinceLastMaint": cycles_since,
+        "maintenanceEvery":    maint_every,
+        "wearScore":           wear,
+        "remainingCycles":     remaining,
+        "needsMaintenance":    needs_maintenance,
+        "forcedToMaintenance": force_maintenance,
+        "lifetimePct":         round(current / lifetime * 100, 1),
+        "recommendation": (
+            "Mantenimiento urgente requerido — máquina fuera de servicio" if force_maintenance
+            else "Programar mantenimiento pronto" if needs_maintenance
+            else f"OK — {remaining} ciclos para próximo servicio"
+        ),
+    })
+
+
+async def analyze_all_machines(payload: dict):
+    """
+    POST /manufacturing/maintenance/analyze-all
+    Runs wear analysis for every machine in the company.
+    """
+    company_id = payload.get("companyId")
+    if not company_id:
+        return JSONResponse({"error": "companyId required"}, 400)
+
+    result = _sp("sp_machines", {"machines": [{"action": "list", "companyId": company_id}]})
+    machines = result.get("machines", [])
+
+    analyses = []
+    for m in machines:
+        r = await analyze_machine({"machineId": m["machineId"], "companyId": company_id})
+        analyses.append(json.loads(r.body))
+
+    alerts = [a for a in analyses if a.get("needsMaintenance")]
+    return JSONResponse({
+        "total":          len(analyses),
+        "needingService": len(alerts),
+        "machines":       analyses,
+        "alerts":         alerts,
+    })
+
+
+async def log_maintenance(payload: dict):
+    """
+    POST /manufacturing/maintenance/log
+    Records completed maintenance and resets machine wear score.
+    """
+    result = _sp("sp_maintenanceLogs", {"logs": [{"action": "insert", **payload}]})
+    return JSONResponse(result)
+
+
+async def get_maintenance_history(payload: dict):
+    """POST /manufacturing/maintenance/history"""
+    result = _sp("sp_maintenanceLogs", {"logs": [{"action": "list", **payload}]})
+    return JSONResponse(result)

--- a/modules/profitabilityOptimizer.py
+++ b/modules/profitabilityOptimizer.py
@@ -1,0 +1,136 @@
+"""
+ProfitabilityOptimizer Agent
+
+Compares ticket price vs real cost per service type and generates
+actionable pricing recommendations.
+
+Logic:
+  1. Pull productionOrders for requested period (default 30 days)
+  2. Group by cycleType → avg real cost, avg ticket price, avg margin
+  3. Flag loss-makers (margin < 0) and thin margins (marginPct < 20%)
+  4. Suggest new prices = avgRealCost × (1 + targetMarginPct / 100)
+  5. Save daily / weekly snapshot
+  6. Return ranked list + suggestions JSON
+"""
+
+from fastapi.responses import JSONResponse
+from databases import connection
+from modules.costEngine import _sp, _get_rates
+import json
+
+
+def _get_orders(company_id: int, period_days: int) -> list:
+    result = _sp("sp_productionOrders", {
+        "orders": [{"action": "list", "companyId": company_id, "periodDays": period_days}]
+    })
+    return result.get("orders", [])
+
+
+async def analyze_profitability(payload: dict):
+    """
+    POST /manufacturing/profitability/analyze
+    Returns per-service-type profitability + global KPIs + price suggestions.
+    """
+    company_id = payload.get("companyId")
+    period_days = int(payload.get("periodDays", 30))
+
+    if not company_id:
+        return JSONResponse({"error": "companyId required"}, 400)
+
+    orders = [o for o in _get_orders(company_id, period_days) if o.get("realCostTotal")]
+    rates = _get_rates(company_id)
+    target_margin = float(rates.get("targetMarginPct", 40.0))
+
+    if not orders:
+        return JSONResponse({
+            "totalOrders": 0,
+            "totalRevenue": 0,
+            "totalRealCost": 0,
+            "totalMargin": 0,
+            "avgMarginPct": 0,
+            "byServiceType": [],
+            "suggestions": [],
+            "message": "No completed orders with cost data in this period",
+        })
+
+    # Group by cycleType
+    groups: dict[str, dict] = {}
+    for o in orders:
+        ct = o.get("cycleType", "unknown")
+        if ct not in groups:
+            groups[ct] = {"count": 0, "revenue": 0, "cost": 0, "margin": 0}
+        g = groups[ct]
+        g["count"] += 1
+        g["revenue"] += float(o.get("ticketPrice") or 0)
+        g["cost"] += float(o.get("realCostTotal") or 0)
+        g["margin"] += float(o.get("margin") or 0)
+
+    by_type = []
+    suggestions = []
+    for ct, g in sorted(groups.items(), key=lambda x: x[1]["margin"] / max(x[1]["revenue"],0.01)):
+        avg_cost = g["cost"] / g["count"]
+        avg_price = g["revenue"] / g["count"]
+        avg_margin = g["margin"] / g["count"]
+        avg_margin_pct = (avg_margin / avg_price * 100) if avg_price > 0 else 0
+        suggested = avg_cost * (1 + target_margin / 100)
+        status = (
+            "loss"  if avg_margin_pct < 0
+            else "thin" if avg_margin_pct < 20
+            else "ok"   if avg_margin_pct < target_margin
+            else "good"
+        )
+
+        entry = {
+            "cycleType":     ct,
+            "orderCount":    g["count"],
+            "avgRealCost":   round(avg_cost, 2),
+            "avgTicketPrice": round(avg_price, 2),
+            "avgMargin":     round(avg_margin, 2),
+            "avgMarginPct":  round(avg_margin_pct, 1),
+            "totalRevenue":  round(g["revenue"], 2),
+            "totalMargin":   round(g["margin"], 2),
+            "status":        status,
+        }
+        by_type.append(entry)
+
+        if status in ("loss", "thin") or avg_price < suggested:
+            suggestions.append({
+                "cycleType":      ct,
+                "currentAvgPrice": round(avg_price, 2),
+                "suggestedPrice":  round(suggested, 2),
+                "delta":           round(suggested - avg_price, 2),
+                "reason": (
+                    f"Pérdida: costo real ${avg_cost:.2f} > precio ${avg_price:.2f}" if status == "loss"
+                    else f"Margen bajo {avg_margin_pct:.1f}% (objetivo {target_margin:.0f}%)"
+                ),
+            })
+
+    total_rev = sum(float(o.get("ticketPrice") or 0) for o in orders)
+    total_cost = sum(float(o.get("realCostTotal") or 0) for o in orders)
+    total_margin = total_rev - total_cost
+    avg_margin_pct_global = (total_margin / total_rev * 100) if total_rev > 0 else 0
+    loss_orders = sum(1 for o in orders if float(o.get("margin") or 0) < 0)
+
+    return JSONResponse({
+        "periodDays":    period_days,
+        "totalOrders":   len(orders),
+        "totalRevenue":  round(total_rev, 2),
+        "totalRealCost": round(total_cost, 2),
+        "totalMargin":   round(total_margin, 2),
+        "avgMarginPct":  round(avg_margin_pct_global, 1),
+        "lossOrders":    loss_orders,
+        "byServiceType": by_type,
+        "suggestions":   suggestions,
+    })
+
+
+async def save_snapshot(payload: dict):
+    """POST /manufacturing/profitability/snapshot — persist daily/weekly/monthly KPIs"""
+    result = _sp("sp_profitabilitySnapshots", {"snapshots": [{"action": "upsert", **payload}]})
+    return JSONResponse(result)
+
+
+async def get_snapshots(payload: dict):
+    """POST /manufacturing/profitability/snapshots"""
+    result = _sp("sp_profitabilitySnapshots", {"snapshots": [{"action": "list", **payload}]})
+    return JSONResponse(result)

--- a/modules/workflowOrchestrator.py
+++ b/modules/workflowOrchestrator.py
@@ -1,0 +1,178 @@
+"""
+WorkflowOrchestrator Agent
+
+Routes incoming manufacturing events to the correct agent and manages
+the production queue. Also exposes the queue state and machine dashboard.
+
+Events handled:
+  new_order       → validate machine availability → insert productionOrder → mark machine in_use
+  start_cycle     → update order status to 'running'
+  complete_cycle  → trigger CostEngine.complete_order → MaintenancePredictor.analyze_machine
+  cancel_order    → free machine
+  get_queue       → return active orders with ETA
+  get_dashboard   → machines + queue + today KPIs in one call
+"""
+
+from fastapi.responses import JSONResponse
+from databases import connection
+from modules.costEngine import _sp, compute_cycle_cost
+from modules.maintenancePredictor import analyze_machine as _analyze_machine
+from modules.profitabilityOptimizer import analyze_profitability as _analyze_profit
+import json
+from datetime import datetime, timezone
+
+
+def _get_active_orders(company_id: int) -> list:
+    result = _sp("sp_productionOrders", {
+        "orders": [{"action": "active", "companyId": company_id}]
+    })
+    return result.get("orders", [])
+
+
+def _get_machines(company_id: int) -> list:
+    result = _sp("sp_machines", {"machines": [{"action": "list", "companyId": company_id}]})
+    return result.get("machines", [])
+
+
+async def create_order(payload: dict):
+    """
+    POST /manufacturing/queue/create
+    Validates machine availability and creates the production order.
+    """
+    company_id = payload.get("companyId")
+    machine_id = payload.get("machineId")
+
+    if not company_id or not machine_id:
+        return JSONResponse({"error": "companyId and machineId required"}, 400)
+
+    result = _sp("sp_productionOrders", {"orders": [{"action": "insert", **payload}]})
+
+    if "error" in result:
+        return JSONResponse(result, 409)
+
+    return JSONResponse({**result, "status": "queued", "message": "Orden creada y máquina asignada"})
+
+
+async def start_cycle(payload: dict):
+    """POST /manufacturing/queue/start — operator confirms cycle started"""
+    order_id = payload.get("orderId")
+    if not order_id:
+        return JSONResponse({"error": "orderId required"}, 400)
+
+    result = _sp("sp_productionOrders", {"orders": [{"action": "start", "orderId": order_id}]})
+    return JSONResponse({**result, "startedAt": datetime.now(timezone.utc).isoformat()})
+
+
+async def complete_cycle(payload: dict):
+    """
+    POST /manufacturing/queue/complete
+    Calculates real cost via CostEngine, updates order, re-analyzes machine wear.
+    """
+    order_id = payload.get("orderId")
+    machine_id = payload.get("machineId")
+    company_id = payload.get("companyId")
+
+    if not all([order_id, machine_id, company_id]):
+        return JSONResponse({"error": "orderId, machineId, companyId required"}, 400)
+
+    # Run CostEngine
+    detergent_grams = float(payload.get("detergentGrams", 0))
+    actual_minutes = payload.get("actualMinutes")
+    ticket_price = float(payload.get("ticketPrice", 0))
+
+    cost = compute_cycle_cost(machine_id, company_id, detergent_grams, actual_minutes, ticket_price)
+
+    _sp("sp_productionOrders", {"orders": [{
+        "action":               "complete",
+        "orderId":              order_id,
+        "realCostElec":         cost["realCostElec"],
+        "realCostWater":        cost["realCostWater"],
+        "realCostDetergent":    cost["realCostDetergent"],
+        "realCostLabor":        cost["realCostLabor"],
+        "realCostDepreciation": cost["realCostDepreciation"],
+        "realCostOverhead":     cost["realCostOverhead"],
+        "realCostTotal":        cost["realCostTotal"],
+        "ticketPrice":          ticket_price,
+        "margin":               cost["margin"],
+        "marginPct":            cost["marginPct"],
+    }]})
+
+    # Re-analyze wear after cycle
+    wear_response = await _analyze_machine({"machineId": machine_id, "companyId": company_id})
+    wear_data = json.loads(wear_response.body)
+
+    return JSONResponse({
+        "orderId":   order_id,
+        "cost":      cost,
+        "wear":      wear_data,
+        "completed": True,
+    })
+
+
+async def cancel_order(payload: dict):
+    """POST /manufacturing/queue/cancel — free machine without cost calculation"""
+    order_id = payload.get("orderId")
+    machine_id = payload.get("machineId")
+    if not order_id:
+        return JSONResponse({"error": "orderId required"}, 400)
+
+    _sp("sp_productionOrders", {"orders": [{"action": "update", "orderId": order_id, "status": "cancelled"}]})
+    if machine_id:
+        _sp("sp_machines", {"machines": [{"action": "update", "machineId": machine_id, "status": "available"}]})
+
+    return JSONResponse({"message": "Orden cancelada, máquina liberada"})
+
+
+async def get_queue(payload: dict):
+    """POST /manufacturing/queue — active orders with ETA"""
+    company_id = payload.get("companyId")
+    if not company_id:
+        return JSONResponse({"error": "companyId required"}, 400)
+
+    orders = _get_active_orders(company_id)
+    now = datetime.now(timezone.utc)
+
+    for o in orders:
+        started_raw = o.get("startedAt")
+        if started_raw and o.get("status") == "running":
+            try:
+                started = datetime.fromisoformat(started_raw.replace("Z", "+00:00"))
+                elapsed = (now - started).seconds // 60
+                remaining = max(0, int(o.get("cycleMinutes", 45)) - elapsed)
+                o["elapsedMinutes"] = elapsed
+                o["remainingMinutes"] = remaining
+                o["etaIso"] = (now.replace(microsecond=0).isoformat())
+            except Exception:
+                pass
+
+    return JSONResponse({"queue": orders, "count": len(orders)})
+
+
+async def get_dashboard(payload: dict):
+    """
+    POST /manufacturing/dashboard
+    Single call returns machines status + queue + today profitability KPIs.
+    """
+    company_id = payload.get("companyId")
+    if not company_id:
+        return JSONResponse({"error": "companyId required"}, 400)
+
+    machines = _get_machines(company_id)
+    queue = _get_active_orders(company_id)
+
+    # Today's quick KPIs from profitability (1-day window)
+    profit_resp = await _analyze_profit({"companyId": company_id, "periodDays": 1})
+    kpis = json.loads(profit_resp.body)
+
+    # Status counts
+    status_counts = {}
+    for m in machines:
+        s = m.get("status", "unknown")
+        status_counts[s] = status_counts.get(s, 0) + 1
+
+    return JSONResponse({
+        "machines":     machines,
+        "queue":        queue,
+        "statusCounts": status_counts,
+        "todayKpis":    kpis,
+    })

--- a/routes_/manufacturing.py
+++ b/routes_/manufacturing.py
@@ -1,0 +1,183 @@
+"""
+Manufacturing Module Routes
+
+All endpoints are under /manufacturing prefix.
+
+WorkflowOrchestrator  → /manufacturing/queue/*   /manufacturing/dashboard
+CostEngine            → /manufacturing/cost-engine/*
+MaintenancePredictor  → /manufacturing/maintenance/*
+ProfitabilityOptimizer→ /manufacturing/profitability/*
+AlertDispatcher       → /manufacturing/alerts/*
+Machines CRUD         → /manufacturing/machines/*
+"""
+from fastapi import APIRouter
+
+from modules.workflowOrchestrator import (
+    create_order, start_cycle, complete_cycle, cancel_order,
+    get_queue, get_dashboard,
+)
+from modules.costEngine import (
+    calculate_cost, complete_order as cost_complete_order,
+    get_utility_rates, upsert_utility_rates,
+)
+from modules.maintenancePredictor import (
+    analyze_machine, analyze_all_machines,
+    log_maintenance, get_maintenance_history,
+)
+from modules.profitabilityOptimizer import (
+    analyze_profitability, save_snapshot, get_snapshots,
+)
+from modules.alertDispatcher import (
+    notify_cycle_done, notify_maintenance_needed,
+    notify_low_margin, notify_low_supply,
+)
+from modules.costEngine import _sp
+
+router = APIRouter(prefix="/manufacturing", tags=["Manufacturing"])
+
+
+# ── Dashboard ─────────────────────────────────────────────────────────────────
+
+@router.post("/dashboard", summary="Full dashboard: machines + queue + today KPIs")
+async def dashboard(payload: dict):
+    return await get_dashboard(payload)
+
+
+# ── Machines CRUD ─────────────────────────────────────────────────────────────
+
+@router.post("/machines", summary="Create a machine")
+async def create_machine(payload: dict):
+    result = _sp("sp_machines", {"machines": [{"action": "insert", **payload}]})
+    from fastapi.responses import JSONResponse
+    return JSONResponse(result)
+
+
+@router.post("/machines/list", summary="List all machines for a company")
+async def list_machines(payload: dict):
+    result = _sp("sp_machines", {"machines": [{"action": "list", **payload}]})
+    from fastapi.responses import JSONResponse
+    return JSONResponse(result)
+
+
+@router.post("/machines/update", summary="Update machine fields")
+async def update_machine(payload: dict):
+    result = _sp("sp_machines", {"machines": [{"action": "update", **payload}]})
+    from fastapi.responses import JSONResponse
+    return JSONResponse(result)
+
+
+# ── Queue / WorkflowOrchestrator ──────────────────────────────────────────────
+
+@router.post("/queue", summary="Get active production queue with ETAs")
+async def queue(payload: dict):
+    return await get_queue(payload)
+
+
+@router.post("/queue/create", summary="Create a production order (validates machine availability)")
+async def queue_create(payload: dict):
+    return await create_order(payload)
+
+
+@router.post("/queue/start", summary="Mark cycle as started")
+async def queue_start(payload: dict):
+    return await start_cycle(payload)
+
+
+@router.post("/queue/complete", summary="Complete cycle: calculate real cost + update wear")
+async def queue_complete(payload: dict):
+    return await complete_cycle(payload)
+
+
+@router.post("/queue/cancel", summary="Cancel order and free machine")
+async def queue_cancel(payload: dict):
+    return await cancel_order(payload)
+
+
+@router.post("/queue/history", summary="Completed orders (last N days)")
+async def queue_history(payload: dict):
+    result = _sp("sp_productionOrders", {"orders": [{"action": "list", **payload}]})
+    from fastapi.responses import JSONResponse
+    return JSONResponse(result)
+
+
+# ── CostEngine ────────────────────────────────────────────────────────────────
+
+@router.post("/cost-engine/calculate", summary="Calculate real wash cost without saving")
+async def cost_calculate(payload: dict):
+    return await calculate_cost(payload)
+
+
+@router.post("/cost-engine/complete", summary="Calculate cost + save to order")
+async def cost_complete(payload: dict):
+    return await cost_complete_order(payload)
+
+
+@router.post("/cost-engine/rates", summary="Get current utility rates")
+async def rates_get(payload: dict):
+    return await get_utility_rates(payload)
+
+
+@router.post("/cost-engine/rates/save", summary="Create or update utility rates")
+async def rates_save(payload: dict):
+    return await upsert_utility_rates(payload)
+
+
+# ── MaintenancePredictor ──────────────────────────────────────────────────────
+
+@router.post("/maintenance/analyze", summary="Analyze wear for one machine")
+async def maintenance_analyze(payload: dict):
+    return await analyze_machine(payload)
+
+
+@router.post("/maintenance/analyze-all", summary="Analyze wear for all company machines")
+async def maintenance_analyze_all(payload: dict):
+    return await analyze_all_machines(payload)
+
+
+@router.post("/maintenance/log", summary="Record completed maintenance service")
+async def maintenance_log(payload: dict):
+    return await log_maintenance(payload)
+
+
+@router.post("/maintenance/history", summary="Get maintenance log history")
+async def maintenance_history(payload: dict):
+    return await get_maintenance_history(payload)
+
+
+# ── ProfitabilityOptimizer ────────────────────────────────────────────────────
+
+@router.post("/profitability/analyze", summary="Analyze margins by service type + price suggestions")
+async def profitability_analyze(payload: dict):
+    return await analyze_profitability(payload)
+
+
+@router.post("/profitability/snapshot", summary="Save periodic profitability snapshot")
+async def profitability_snapshot(payload: dict):
+    return await save_snapshot(payload)
+
+
+@router.post("/profitability/snapshots", summary="Get profitability snapshot history")
+async def profitability_snapshots(payload: dict):
+    return await get_snapshots(payload)
+
+
+# ── AlertDispatcher ───────────────────────────────────────────────────────────
+
+@router.post("/alerts/cycle-done", summary="Notify client: cycle complete (Push + WhatsApp)")
+async def alert_cycle_done(payload: dict):
+    return await notify_cycle_done(payload)
+
+
+@router.post("/alerts/maintenance", summary="Notify manager: machine needs maintenance")
+async def alert_maintenance(payload: dict):
+    return await notify_maintenance_needed(payload)
+
+
+@router.post("/alerts/low-margin", summary="Notify manager: order closed with low/negative margin")
+async def alert_low_margin(payload: dict):
+    return await notify_low_margin(payload)
+
+
+@router.post("/alerts/low-supply", summary="Notify manager: supply running low")
+async def alert_low_supply(payload: dict):
+    return await notify_low_supply(payload)

--- a/sql/sp_manufacturing.sql
+++ b/sql/sp_manufacturing.sql
@@ -1,0 +1,615 @@
+-- ============================================================
+-- Manufacturing Module — Laundry Machine Cost Tracking
+-- Run once in Azure SQL. Order: this file first.
+-- ============================================================
+
+-- ── machines ────────────────────────────────────────────────
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'machines')
+CREATE TABLE [dbo].[machines] (
+    machineId           INT IDENTITY PRIMARY KEY,
+    companyId           INT NOT NULL,
+    name                NVARCHAR(100) NOT NULL,
+    machineType         NVARCHAR(30)  NOT NULL DEFAULT 'washer', -- washer | dryer | combo
+    capacityKg          DECIMAL(8,2)  NOT NULL DEFAULT 0,
+    kwhPerCycle         DECIMAL(8,4)  NOT NULL DEFAULT 0,   -- electricity per cycle
+    litersPerCycle      DECIMAL(8,2)  NOT NULL DEFAULT 0,   -- water per cycle
+    cycleMinutes        INT           NOT NULL DEFAULT 45,  -- avg cycle duration
+    purchaseCost        DECIMAL(18,2) NOT NULL DEFAULT 0,
+    lifetimeCycles      INT           NOT NULL DEFAULT 5000, -- expected total cycles
+    currentCycleCount   INT           NOT NULL DEFAULT 0,
+    maintenanceEvery    INT           NOT NULL DEFAULT 200,  -- cycles between services
+    lastMaintenanceCycle INT          NOT NULL DEFAULT 0,
+    wearScore           INT           NOT NULL DEFAULT 0,   -- 0-100, higher = more worn
+    status              NVARCHAR(20)  NOT NULL DEFAULT 'available', -- available | in_use | maintenance | retired
+    location            NVARCHAR(100) NULL,
+    serialNumber        NVARCHAR(100) NULL,
+    notes               NVARCHAR(500) NULL,
+    createdAt           DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+    updatedAt           DATETIME2     NULL,
+)
+GO
+
+-- ── utilityRates ─────────────────────────────────────────────
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'utilityRates')
+CREATE TABLE [dbo].[utilityRates] (
+    rateId              INT IDENTITY PRIMARY KEY,
+    companyId           INT NOT NULL,
+    electricityPerKwh   DECIMAL(10,4) NOT NULL DEFAULT 3.20,  -- MXN per kWh (CFE DAC avg)
+    waterPerLiter       DECIMAL(10,4) NOT NULL DEFAULT 0.015, -- MXN per L (SIMAS avg)
+    detergentPerGram    DECIMAL(10,4) NOT NULL DEFAULT 0.08,  -- MXN per gram
+    laborPerHour        DECIMAL(10,2) NOT NULL DEFAULT 80.00, -- MXN per hour
+    overheadPct         DECIMAL(5,2)  NOT NULL DEFAULT 15.00, -- % overhead on top
+    targetMarginPct     DECIMAL(5,2)  NOT NULL DEFAULT 40.00, -- target profit margin %
+    effectiveFrom       DATE          NOT NULL DEFAULT CAST(GETUTCDATE() AS DATE),
+    createdAt           DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+    CONSTRAINT UQ_utilityRates UNIQUE (companyId, effectiveFrom)
+)
+GO
+
+-- ── productionOrders ─────────────────────────────────────────
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'productionOrders')
+CREATE TABLE [dbo].[productionOrders] (
+    orderId             INT IDENTITY PRIMARY KEY,
+    companyId           INT           NOT NULL,
+    clientId            INT           NULL,
+    ticketId            INT           NULL,  -- links to existing tickets table
+    machineId           INT           NOT NULL,
+    assignedBy          INT           NULL,  -- userId
+    cycleType           NVARCHAR(30)  NOT NULL DEFAULT 'normal', -- delicate | normal | heavy | sanitize
+    weightKg            DECIMAL(8,2)  NOT NULL DEFAULT 0,
+    detergentGrams      DECIMAL(8,2)  NOT NULL DEFAULT 0,
+    extraDetergent      BIT           NOT NULL DEFAULT 0,
+    status              NVARCHAR(20)  NOT NULL DEFAULT 'queued', -- queued | running | done | cancelled
+    startedAt           DATETIME2     NULL,
+    completedAt         DATETIME2     NULL,
+    estimatedMinutes    INT           NOT NULL DEFAULT 45,
+    actualMinutes       INT           NULL,
+    notes               NVARCHAR(500) NULL,
+    -- cost snapshot (filled by CostEngine after cycle)
+    realCostElec        DECIMAL(10,4) NULL,
+    realCostWater       DECIMAL(10,4) NULL,
+    realCostDetergent   DECIMAL(10,4) NULL,
+    realCostLabor       DECIMAL(10,4) NULL,
+    realCostDepreciation DECIMAL(10,4) NULL,
+    realCostOverhead    DECIMAL(10,4) NULL,
+    realCostTotal       DECIMAL(10,4) NULL,
+    -- income link
+    ticketPrice         DECIMAL(10,2) NULL,  -- what customer paid
+    margin              DECIMAL(10,4) NULL,  -- ticketPrice - realCostTotal
+    marginPct           DECIMAL(6,2)  NULL,
+    -- alert flags
+    alertSent           BIT           NOT NULL DEFAULT 0,
+    maintenanceTriggered BIT          NOT NULL DEFAULT 0,
+    createdAt           DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+    updatedAt           DATETIME2     NULL,
+)
+GO
+
+-- ── maintenanceLogs ──────────────────────────────────────────
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'maintenanceLogs')
+CREATE TABLE [dbo].[maintenanceLogs] (
+    logId               INT IDENTITY PRIMARY KEY,
+    companyId           INT           NOT NULL,
+    machineId           INT           NOT NULL,
+    logType             NVARCHAR(30)  NOT NULL DEFAULT 'scheduled', -- scheduled | emergency | inspection
+    description         NVARCHAR(500) NULL,
+    technicianName      NVARCHAR(100) NULL,
+    costMXN             DECIMAL(10,2) NOT NULL DEFAULT 0,
+    cycleAtMaintenance  INT           NOT NULL DEFAULT 0,
+    wearBefore          INT           NOT NULL DEFAULT 0,
+    wearAfter           INT           NOT NULL DEFAULT 0,
+    partsReplaced       NVARCHAR(500) NULL,
+    nextServiceCycle    INT           NULL,
+    completedAt         DATETIME2     NULL,
+    createdAt           DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+)
+GO
+
+-- ── profitabilitySnapshots ───────────────────────────────────
+IF NOT EXISTS (SELECT * FROM sys.tables WHERE name = 'profitabilitySnapshots')
+CREATE TABLE [dbo].[profitabilitySnapshots] (
+    snapshotId          INT IDENTITY PRIMARY KEY,
+    companyId           INT           NOT NULL,
+    snapshotDate        DATE          NOT NULL DEFAULT CAST(GETUTCDATE() AS DATE),
+    periodType          NVARCHAR(10)  NOT NULL DEFAULT 'daily', -- daily | weekly | monthly
+    totalOrders         INT           NOT NULL DEFAULT 0,
+    totalRevenue        DECIMAL(18,2) NOT NULL DEFAULT 0,
+    totalRealCost       DECIMAL(18,2) NOT NULL DEFAULT 0,
+    totalMargin         DECIMAL(18,2) NOT NULL DEFAULT 0,
+    avgMarginPct        DECIMAL(6,2)  NOT NULL DEFAULT 0,
+    bestServiceType     NVARCHAR(50)  NULL,
+    worstServiceType    NVARCHAR(50)  NULL,
+    lossOrders          INT           NOT NULL DEFAULT 0,
+    suggestedPriceAdj   NVARCHAR(MAX) NULL,  -- JSON of suggested price changes
+    createdAt           DATETIME2     NOT NULL DEFAULT GETUTCDATE(),
+    CONSTRAINT UQ_profitSnap UNIQUE (companyId, snapshotDate, periodType)
+)
+GO
+
+-- ============================================================
+-- sp_machines
+-- ============================================================
+IF OBJECT_ID('dbo.sp_machines','P') IS NOT NULL DROP PROCEDURE dbo.sp_machines;
+GO
+CREATE PROCEDURE [dbo].[sp_machines]
+    @pjsonfile NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    BEGIN TRY
+        DECLARE @action         NVARCHAR(20)  = JSON_VALUE(@pjsonfile,'$.machines[0].action')
+        DECLARE @machineId      INT           = JSON_VALUE(@pjsonfile,'$.machines[0].machineId')
+        DECLARE @companyId      INT           = JSON_VALUE(@pjsonfile,'$.machines[0].companyId')
+        DECLARE @name           NVARCHAR(100) = JSON_VALUE(@pjsonfile,'$.machines[0].name')
+        DECLARE @machineType    NVARCHAR(30)  = JSON_VALUE(@pjsonfile,'$.machines[0].machineType')
+        DECLARE @capacityKg     DECIMAL(8,2)  = JSON_VALUE(@pjsonfile,'$.machines[0].capacityKg')
+        DECLARE @kwhPerCycle    DECIMAL(8,4)  = JSON_VALUE(@pjsonfile,'$.machines[0].kwhPerCycle')
+        DECLARE @litersPerCycle DECIMAL(8,2)  = JSON_VALUE(@pjsonfile,'$.machines[0].litersPerCycle')
+        DECLARE @cycleMinutes   INT           = JSON_VALUE(@pjsonfile,'$.machines[0].cycleMinutes')
+        DECLARE @purchaseCost   DECIMAL(18,2) = JSON_VALUE(@pjsonfile,'$.machines[0].purchaseCost')
+        DECLARE @lifetimeCycles INT           = JSON_VALUE(@pjsonfile,'$.machines[0].lifetimeCycles')
+        DECLARE @maintenanceEvery INT         = JSON_VALUE(@pjsonfile,'$.machines[0].maintenanceEvery')
+        DECLARE @status         NVARCHAR(20)  = JSON_VALUE(@pjsonfile,'$.machines[0].status')
+        DECLARE @location       NVARCHAR(100) = JSON_VALUE(@pjsonfile,'$.machines[0].location')
+        DECLARE @serialNumber   NVARCHAR(100) = JSON_VALUE(@pjsonfile,'$.machines[0].serialNumber')
+        DECLARE @notes          NVARCHAR(500) = JSON_VALUE(@pjsonfile,'$.machines[0].notes')
+        DECLARE @cycleIncrement INT           = JSON_VALUE(@pjsonfile,'$.machines[0].cycleIncrement')
+        DECLARE @wearScore      INT           = JSON_VALUE(@pjsonfile,'$.machines[0].wearScore')
+
+        IF @action = 'insert'
+        BEGIN
+            INSERT INTO [dbo].[machines]
+                (companyId, name, machineType, capacityKg, kwhPerCycle, litersPerCycle,
+                 cycleMinutes, purchaseCost, lifetimeCycles, maintenanceEvery, status, location, serialNumber, notes)
+            VALUES
+                (@companyId, @name, ISNULL(@machineType,'washer'), ISNULL(@capacityKg,0),
+                 ISNULL(@kwhPerCycle,0), ISNULL(@litersPerCycle,0), ISNULL(@cycleMinutes,45),
+                 ISNULL(@purchaseCost,0), ISNULL(@lifetimeCycles,5000), ISNULL(@maintenanceEvery,200),
+                 ISNULL(@status,'available'), @location, @serialNumber, @notes)
+
+            SELECT (SELECT SCOPE_IDENTITY() AS machineId FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [jsonResult]
+        END
+
+        ELSE IF @action = 'update'
+        BEGIN
+            UPDATE [dbo].[machines] SET
+                name            = ISNULL(@name, name),
+                machineType     = ISNULL(@machineType, machineType),
+                capacityKg      = ISNULL(@capacityKg, capacityKg),
+                kwhPerCycle     = ISNULL(@kwhPerCycle, kwhPerCycle),
+                litersPerCycle  = ISNULL(@litersPerCycle, litersPerCycle),
+                cycleMinutes    = ISNULL(@cycleMinutes, cycleMinutes),
+                purchaseCost    = ISNULL(@purchaseCost, purchaseCost),
+                lifetimeCycles  = ISNULL(@lifetimeCycles, lifetimeCycles),
+                maintenanceEvery= ISNULL(@maintenanceEvery, maintenanceEvery),
+                status          = ISNULL(@status, status),
+                location        = ISNULL(@location, location),
+                serialNumber    = ISNULL(@serialNumber, serialNumber),
+                notes           = ISNULL(@notes, notes),
+                -- increment cycle counter if provided
+                currentCycleCount = currentCycleCount + ISNULL(@cycleIncrement, 0),
+                lastMaintenanceCycle = CASE WHEN @wearScore IS NOT NULL AND @wearScore < wearScore
+                                           THEN currentCycleCount + ISNULL(@cycleIncrement,0)
+                                           ELSE lastMaintenanceCycle END,
+                wearScore       = ISNULL(@wearScore, wearScore),
+                updatedAt       = GETUTCDATE()
+            WHERE machineId = @machineId
+
+            SELECT '{"message":"updated"}' AS [jsonResult]
+        END
+
+        ELSE IF @action = 'list'
+        BEGIN
+            SELECT ISNULL(
+                (SELECT machineId, companyId, name, machineType, capacityKg, kwhPerCycle,
+                        litersPerCycle, cycleMinutes, purchaseCost, lifetimeCycles,
+                        currentCycleCount, maintenanceEvery, lastMaintenanceCycle, wearScore,
+                        status, location, serialNumber, notes,
+                        CONVERT(NVARCHAR, createdAt, 127) AS createdAt,
+                        CONVERT(NVARCHAR, updatedAt, 127) AS updatedAt
+                 FROM [dbo].[machines]
+                 WHERE companyId = @companyId
+                 ORDER BY name
+                 FOR JSON PATH, ROOT('machines')),
+                '{"machines":[]}'
+            ) AS [jsonResult]
+        END
+
+        ELSE IF @action = 'one'
+        BEGIN
+            SELECT ISNULL(
+                (SELECT machineId, companyId, name, machineType, capacityKg, kwhPerCycle,
+                        litersPerCycle, cycleMinutes, purchaseCost, lifetimeCycles,
+                        currentCycleCount, maintenanceEvery, lastMaintenanceCycle, wearScore,
+                        status, location, serialNumber, notes,
+                        CONVERT(NVARCHAR, createdAt, 127) AS createdAt
+                 FROM [dbo].[machines]
+                 WHERE machineId = @machineId
+                 FOR JSON PATH, WITHOUT_ARRAY_WRAPPER),
+                '{}'
+            ) AS [jsonResult]
+        END
+    END TRY
+    BEGIN CATCH
+        SELECT ('{"error":"' + REPLACE(ERROR_MESSAGE(),'"','\"') + '"}') AS [jsonResult]
+    END CATCH
+END
+GO
+
+-- ============================================================
+-- sp_productionOrders
+-- ============================================================
+IF OBJECT_ID('dbo.sp_productionOrders','P') IS NOT NULL DROP PROCEDURE dbo.sp_productionOrders;
+GO
+CREATE PROCEDURE [dbo].[sp_productionOrders]
+    @pjsonfile NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    BEGIN TRY
+        DECLARE @action         NVARCHAR(20)  = JSON_VALUE(@pjsonfile,'$.orders[0].action')
+        DECLARE @orderId        INT           = JSON_VALUE(@pjsonfile,'$.orders[0].orderId')
+        DECLARE @companyId      INT           = JSON_VALUE(@pjsonfile,'$.orders[0].companyId')
+        DECLARE @clientId       INT           = JSON_VALUE(@pjsonfile,'$.orders[0].clientId')
+        DECLARE @ticketId       INT           = JSON_VALUE(@pjsonfile,'$.orders[0].ticketId')
+        DECLARE @machineId      INT           = JSON_VALUE(@pjsonfile,'$.orders[0].machineId')
+        DECLARE @assignedBy     INT           = JSON_VALUE(@pjsonfile,'$.orders[0].assignedBy')
+        DECLARE @cycleType      NVARCHAR(30)  = JSON_VALUE(@pjsonfile,'$.orders[0].cycleType')
+        DECLARE @weightKg       DECIMAL(8,2)  = JSON_VALUE(@pjsonfile,'$.orders[0].weightKg')
+        DECLARE @detergentGrams DECIMAL(8,2)  = JSON_VALUE(@pjsonfile,'$.orders[0].detergentGrams')
+        DECLARE @extraDetergent BIT           = JSON_VALUE(@pjsonfile,'$.orders[0].extraDetergent')
+        DECLARE @status         NVARCHAR(20)  = JSON_VALUE(@pjsonfile,'$.orders[0].status')
+        DECLARE @startedAt      DATETIME2     = JSON_VALUE(@pjsonfile,'$.orders[0].startedAt')
+        DECLARE @completedAt    DATETIME2     = JSON_VALUE(@pjsonfile,'$.orders[0].completedAt')
+        DECLARE @actualMinutes  INT           = JSON_VALUE(@pjsonfile,'$.orders[0].actualMinutes')
+        DECLARE @notes          NVARCHAR(500) = JSON_VALUE(@pjsonfile,'$.orders[0].notes')
+        DECLARE @ticketPrice    DECIMAL(10,2) = JSON_VALUE(@pjsonfile,'$.orders[0].ticketPrice')
+        DECLARE @realCostTotal  DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostTotal')
+        DECLARE @realCostElec   DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostElec')
+        DECLARE @realCostWater  DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostWater')
+        DECLARE @realCostDet    DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostDetergent')
+        DECLARE @realCostLabor  DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostLabor')
+        DECLARE @realCostDeprec DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostDepreciation')
+        DECLARE @realCostOvrh   DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].realCostOverhead')
+        DECLARE @margin         DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.orders[0].margin')
+        DECLARE @marginPct      DECIMAL(6,2)  = JSON_VALUE(@pjsonfile,'$.orders[0].marginPct')
+        DECLARE @alertSent      BIT           = JSON_VALUE(@pjsonfile,'$.orders[0].alertSent')
+        DECLARE @periodDays     INT           = ISNULL(JSON_VALUE(@pjsonfile,'$.orders[0].periodDays'), 30)
+
+        IF @action = 'insert'
+        BEGIN
+            -- Validate machine is available
+            IF NOT EXISTS (SELECT 1 FROM [dbo].[machines] WHERE machineId=@machineId AND status='available')
+            BEGIN
+                SELECT '{"error":"Machine not available"}' AS [jsonResult]
+                RETURN
+            END
+
+            INSERT INTO [dbo].[productionOrders]
+                (companyId, clientId, ticketId, machineId, assignedBy, cycleType,
+                 weightKg, detergentGrams, extraDetergent, status, notes,
+                 estimatedMinutes)
+            SELECT @companyId, @clientId, @ticketId, @machineId, @assignedBy,
+                   ISNULL(@cycleType,'normal'), ISNULL(@weightKg,0), ISNULL(@detergentGrams,0),
+                   ISNULL(@extraDetergent,0), 'queued', @notes, cycleMinutes
+            FROM [dbo].[machines] WHERE machineId = @machineId
+
+            -- Mark machine as in_use
+            UPDATE [dbo].[machines] SET status='in_use', updatedAt=GETUTCDATE() WHERE machineId=@machineId
+
+            SELECT (SELECT SCOPE_IDENTITY() AS orderId FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [jsonResult]
+        END
+
+        ELSE IF @action = 'start'
+        BEGIN
+            UPDATE [dbo].[productionOrders]
+            SET status='running', startedAt=GETUTCDATE(), updatedAt=GETUTCDATE()
+            WHERE orderId=@orderId
+            SELECT '{"message":"started"}' AS [jsonResult]
+        END
+
+        ELSE IF @action = 'complete'
+        BEGIN
+            DECLARE @startTime DATETIME2 = (SELECT startedAt FROM [dbo].[productionOrders] WHERE orderId=@orderId)
+            DECLARE @mins INT = DATEDIFF(MINUTE, @startTime, GETUTCDATE())
+
+            UPDATE [dbo].[productionOrders]
+            SET status='done', completedAt=GETUTCDATE(), actualMinutes=@mins,
+                realCostElec=@realCostElec, realCostWater=@realCostWater,
+                realCostDetergent=@realCostDet, realCostLabor=@realCostLabor,
+                realCostDepreciation=@realCostDeprec, realCostOverhead=@realCostOvrh,
+                realCostTotal=@realCostTotal, ticketPrice=@ticketPrice,
+                margin=@margin, marginPct=@marginPct,
+                updatedAt=GETUTCDATE()
+            WHERE orderId=@orderId
+
+            -- Free machine, increment cycle
+            UPDATE [dbo].[machines]
+            SET status='available',
+                currentCycleCount = currentCycleCount + 1,
+                updatedAt=GETUTCDATE()
+            WHERE machineId = (SELECT machineId FROM [dbo].[productionOrders] WHERE orderId=@orderId)
+
+            SELECT '{"message":"completed"}' AS [jsonResult]
+        END
+
+        ELSE IF @action = 'alert_sent'
+        BEGIN
+            UPDATE [dbo].[productionOrders] SET alertSent=1, updatedAt=GETUTCDATE() WHERE orderId=@orderId
+            SELECT '{"message":"alert_sent"}' AS [jsonResult]
+        END
+
+        ELSE IF @action = 'list'
+        BEGIN
+            SELECT ISNULL(
+                (SELECT o.orderId, o.companyId, o.clientId, o.ticketId, o.machineId,
+                        o.cycleType, o.weightKg, o.detergentGrams, o.status,
+                        o.estimatedMinutes, o.actualMinutes,
+                        o.realCostTotal, o.ticketPrice, o.margin, o.marginPct,
+                        o.alertSent,
+                        CONVERT(NVARCHAR,o.startedAt,127)   AS startedAt,
+                        CONVERT(NVARCHAR,o.completedAt,127) AS completedAt,
+                        CONVERT(NVARCHAR,o.createdAt,127)   AS createdAt,
+                        m.name AS machineName, m.machineType
+                 FROM [dbo].[productionOrders] o
+                 LEFT JOIN [dbo].[machines] m ON m.machineId = o.machineId
+                 WHERE o.companyId = @companyId
+                   AND o.createdAt >= DATEADD(DAY, -@periodDays, GETUTCDATE())
+                 ORDER BY o.createdAt DESC
+                 FOR JSON PATH, ROOT('orders')),
+                '{"orders":[]}'
+            ) AS [jsonResult]
+        END
+
+        ELSE IF @action = 'active'
+        BEGIN
+            -- Orders currently running or queued
+            SELECT ISNULL(
+                (SELECT o.orderId, o.machineId, o.clientId, o.cycleType, o.status,
+                        o.estimatedMinutes, o.alertSent,
+                        CONVERT(NVARCHAR,o.startedAt,127) AS startedAt,
+                        m.name AS machineName, m.cycleMinutes
+                 FROM [dbo].[productionOrders] o
+                 JOIN [dbo].[machines] m ON m.machineId = o.machineId
+                 WHERE o.companyId = @companyId AND o.status IN ('queued','running')
+                 ORDER BY o.createdAt
+                 FOR JSON PATH, ROOT('orders')),
+                '{"orders":[]}'
+            ) AS [jsonResult]
+        END
+    END TRY
+    BEGIN CATCH
+        SELECT ('{"error":"' + REPLACE(ERROR_MESSAGE(),'"','\"') + '"}') AS [jsonResult]
+    END CATCH
+END
+GO
+
+-- ============================================================
+-- sp_utilityRates
+-- ============================================================
+IF OBJECT_ID('dbo.sp_utilityRates','P') IS NOT NULL DROP PROCEDURE dbo.sp_utilityRates;
+GO
+CREATE PROCEDURE [dbo].[sp_utilityRates]
+    @pjsonfile NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    BEGIN TRY
+        DECLARE @action         NVARCHAR(10)  = JSON_VALUE(@pjsonfile,'$.rates[0].action')
+        DECLARE @companyId      INT           = JSON_VALUE(@pjsonfile,'$.rates[0].companyId')
+        DECLARE @elec           DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.rates[0].electricityPerKwh')
+        DECLARE @water          DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.rates[0].waterPerLiter')
+        DECLARE @det            DECIMAL(10,4) = JSON_VALUE(@pjsonfile,'$.rates[0].detergentPerGram')
+        DECLARE @labor          DECIMAL(10,2) = JSON_VALUE(@pjsonfile,'$.rates[0].laborPerHour')
+        DECLARE @overhead       DECIMAL(5,2)  = JSON_VALUE(@pjsonfile,'$.rates[0].overheadPct')
+        DECLARE @margin         DECIMAL(5,2)  = JSON_VALUE(@pjsonfile,'$.rates[0].targetMarginPct')
+        DECLARE @effFrom        DATE          = ISNULL(JSON_VALUE(@pjsonfile,'$.rates[0].effectiveFrom'), CAST(GETUTCDATE() AS DATE))
+
+        IF @action = 'upsert'
+        BEGIN
+            MERGE [dbo].[utilityRates] AS t
+            USING (SELECT @companyId AS companyId, @effFrom AS effectiveFrom) AS s
+                ON t.companyId=s.companyId AND t.effectiveFrom=s.effectiveFrom
+            WHEN MATCHED THEN UPDATE SET
+                electricityPerKwh=ISNULL(@elec,t.electricityPerKwh),
+                waterPerLiter=ISNULL(@water,t.waterPerLiter),
+                detergentPerGram=ISNULL(@det,t.detergentPerGram),
+                laborPerHour=ISNULL(@labor,t.laborPerHour),
+                overheadPct=ISNULL(@overhead,t.overheadPct),
+                targetMarginPct=ISNULL(@margin,t.targetMarginPct)
+            WHEN NOT MATCHED THEN INSERT
+                (companyId,electricityPerKwh,waterPerLiter,detergentPerGram,laborPerHour,overheadPct,targetMarginPct,effectiveFrom)
+            VALUES (@companyId,ISNULL(@elec,3.20),ISNULL(@water,0.015),ISNULL(@det,0.08),
+                    ISNULL(@labor,80),ISNULL(@overhead,15),ISNULL(@margin,40),@effFrom);
+
+            SELECT (SELECT TOP 1 electricityPerKwh,waterPerLiter,detergentPerGram,
+                           laborPerHour,overheadPct,targetMarginPct,
+                           CONVERT(NVARCHAR,effectiveFrom,23) AS effectiveFrom
+                    FROM [dbo].[utilityRates] WHERE companyId=@companyId
+                    ORDER BY effectiveFrom DESC
+                    FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [jsonResult]
+        END
+
+        ELSE IF @action = 'get'
+        BEGIN
+            SELECT ISNULL(
+                (SELECT TOP 1 rateId, electricityPerKwh, waterPerLiter, detergentPerGram,
+                        laborPerHour, overheadPct, targetMarginPct,
+                        CONVERT(NVARCHAR, effectiveFrom, 23) AS effectiveFrom
+                 FROM [dbo].[utilityRates]
+                 WHERE companyId=@companyId AND effectiveFrom <= CAST(GETUTCDATE() AS DATE)
+                 ORDER BY effectiveFrom DESC
+                 FOR JSON PATH, WITHOUT_ARRAY_WRAPPER),
+                '{"electricityPerKwh":3.20,"waterPerLiter":0.015,"detergentPerGram":0.08,"laborPerHour":80,"overheadPct":15,"targetMarginPct":40}'
+            ) AS [jsonResult]
+        END
+    END TRY
+    BEGIN CATCH
+        SELECT ('{"error":"' + REPLACE(ERROR_MESSAGE(),'"','\"') + '"}') AS [jsonResult]
+    END CATCH
+END
+GO
+
+-- ============================================================
+-- sp_maintenanceLogs
+-- ============================================================
+IF OBJECT_ID('dbo.sp_maintenanceLogs','P') IS NOT NULL DROP PROCEDURE dbo.sp_maintenanceLogs;
+GO
+CREATE PROCEDURE [dbo].[sp_maintenanceLogs]
+    @pjsonfile NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    BEGIN TRY
+        DECLARE @action         NVARCHAR(10)  = JSON_VALUE(@pjsonfile,'$.logs[0].action')
+        DECLARE @companyId      INT           = JSON_VALUE(@pjsonfile,'$.logs[0].companyId')
+        DECLARE @machineId      INT           = JSON_VALUE(@pjsonfile,'$.logs[0].machineId')
+        DECLARE @logType        NVARCHAR(30)  = JSON_VALUE(@pjsonfile,'$.logs[0].logType')
+        DECLARE @description    NVARCHAR(500) = JSON_VALUE(@pjsonfile,'$.logs[0].description')
+        DECLARE @techName       NVARCHAR(100) = JSON_VALUE(@pjsonfile,'$.logs[0].technicianName')
+        DECLARE @costMXN        DECIMAL(10,2) = JSON_VALUE(@pjsonfile,'$.logs[0].costMXN')
+        DECLARE @wearBefore     INT           = JSON_VALUE(@pjsonfile,'$.logs[0].wearBefore')
+        DECLARE @wearAfter      INT           = JSON_VALUE(@pjsonfile,'$.logs[0].wearAfter')
+        DECLARE @parts          NVARCHAR(500) = JSON_VALUE(@pjsonfile,'$.logs[0].partsReplaced')
+
+        IF @action = 'insert'
+        BEGIN
+            DECLARE @currCycle INT = ISNULL((SELECT currentCycleCount FROM [dbo].[machines] WHERE machineId=@machineId), 0)
+            DECLARE @nextService INT = @currCycle + ISNULL((SELECT maintenanceEvery FROM [dbo].[machines] WHERE machineId=@machineId), 200)
+
+            INSERT INTO [dbo].[maintenanceLogs]
+                (companyId, machineId, logType, description, technicianName, costMXN,
+                 cycleAtMaintenance, wearBefore, wearAfter, partsReplaced, nextServiceCycle, completedAt)
+            VALUES
+                (@companyId, @machineId, ISNULL(@logType,'scheduled'), @description, @techName,
+                 ISNULL(@costMXN,0), @currCycle, ISNULL(@wearBefore,0), ISNULL(@wearAfter,0),
+                 @parts, @nextService, GETUTCDATE())
+
+            -- Reset machine wear and update last maintenance
+            UPDATE [dbo].[machines]
+            SET wearScore=ISNULL(@wearAfter,0),
+                lastMaintenanceCycle=@currCycle,
+                status='available',
+                updatedAt=GETUTCDATE()
+            WHERE machineId=@machineId
+
+            SELECT (SELECT SCOPE_IDENTITY() AS logId FOR JSON PATH, WITHOUT_ARRAY_WRAPPER) AS [jsonResult]
+        END
+
+        ELSE IF @action = 'list'
+        BEGIN
+            SELECT ISNULL(
+                (SELECT l.logId, l.machineId, l.logType, l.description, l.technicianName,
+                        l.costMXN, l.cycleAtMaintenance, l.wearBefore, l.wearAfter,
+                        l.partsReplaced, l.nextServiceCycle,
+                        CONVERT(NVARCHAR, l.completedAt, 127) AS completedAt,
+                        CONVERT(NVARCHAR, l.createdAt, 127)   AS createdAt,
+                        m.name AS machineName
+                 FROM [dbo].[maintenanceLogs] l
+                 JOIN [dbo].[machines] m ON m.machineId=l.machineId
+                 WHERE l.companyId=@companyId
+                   AND (@machineId IS NULL OR l.machineId=@machineId)
+                 ORDER BY l.createdAt DESC
+                 FOR JSON PATH, ROOT('logs')),
+                '{"logs":[]}'
+            ) AS [jsonResult]
+        END
+    END TRY
+    BEGIN CATCH
+        SELECT ('{"error":"' + REPLACE(ERROR_MESSAGE(),'"','\"') + '"}') AS [jsonResult]
+    END CATCH
+END
+GO
+
+-- ============================================================
+-- sp_profitabilitySnapshots
+-- ============================================================
+IF OBJECT_ID('dbo.sp_profitabilitySnapshots','P') IS NOT NULL DROP PROCEDURE dbo.sp_profitabilitySnapshots;
+GO
+CREATE PROCEDURE [dbo].[sp_profitabilitySnapshots]
+    @pjsonfile NVARCHAR(MAX)
+AS
+BEGIN
+    SET NOCOUNT ON;
+    BEGIN TRY
+        DECLARE @action     NVARCHAR(10) = JSON_VALUE(@pjsonfile,'$.snapshots[0].action')
+        DECLARE @companyId  INT          = JSON_VALUE(@pjsonfile,'$.snapshots[0].companyId')
+        DECLARE @periodType NVARCHAR(10) = ISNULL(JSON_VALUE(@pjsonfile,'$.snapshots[0].periodType'),'daily')
+        DECLARE @snapDate   DATE         = ISNULL(JSON_VALUE(@pjsonfile,'$.snapshots[0].snapshotDate'), CAST(GETUTCDATE() AS DATE))
+        DECLARE @limitRows  INT          = ISNULL(JSON_VALUE(@pjsonfile,'$.snapshots[0].limit'), 30)
+
+        IF @action = 'upsert'
+        BEGIN
+            -- Aggregate from productionOrders for the period
+            DECLARE @startDate DATE, @endDate DATE
+            SET @endDate = @snapDate
+            SET @startDate = CASE @periodType
+                WHEN 'weekly'  THEN DATEADD(DAY,-6,@snapDate)
+                WHEN 'monthly' THEN DATEADD(DAY,-29,@snapDate)
+                ELSE @snapDate END
+
+            SELECT
+                @companyId AS companyId,
+                COUNT(*)                                    AS totalOrders,
+                ISNULL(SUM(ticketPrice),0)                  AS totalRevenue,
+                ISNULL(SUM(realCostTotal),0)                AS totalRealCost,
+                ISNULL(SUM(margin),0)                       AS totalMargin,
+                ISNULL(AVG(marginPct),0)                    AS avgMarginPct,
+                SUM(CASE WHEN margin < 0 THEN 1 ELSE 0 END) AS lossOrders
+            INTO #snap
+            FROM [dbo].[productionOrders]
+            WHERE companyId=@companyId AND status='done'
+              AND CAST(completedAt AS DATE) BETWEEN @startDate AND @endDate
+
+            DECLARE @totOrd INT, @totRev DECIMAL(18,2), @totCost DECIMAL(18,2),
+                    @totMrg DECIMAL(18,2), @avgMrg DECIMAL(6,2), @lossOrd INT
+            SELECT @totOrd=totalOrders,@totRev=totalRevenue,@totCost=totalRealCost,
+                   @totMrg=totalMargin,@avgMrg=avgMarginPct,@lossOrd=lossOrders FROM #snap
+            DROP TABLE #snap
+
+            -- Best / worst cycle type by margin
+            DECLARE @best NVARCHAR(50), @worst NVARCHAR(50)
+            SELECT TOP 1 @best=cycleType FROM [dbo].[productionOrders]
+            WHERE companyId=@companyId AND status='done' AND CAST(completedAt AS DATE) BETWEEN @startDate AND @endDate
+            GROUP BY cycleType ORDER BY AVG(marginPct) DESC
+
+            SELECT TOP 1 @worst=cycleType FROM [dbo].[productionOrders]
+            WHERE companyId=@companyId AND status='done' AND CAST(completedAt AS DATE) BETWEEN @startDate AND @endDate
+            GROUP BY cycleType ORDER BY AVG(marginPct) ASC
+
+            MERGE [dbo].[profitabilitySnapshots] AS t
+            USING (SELECT @companyId AS companyId, @snapDate AS snapshotDate, @periodType AS periodType) AS s
+                ON t.companyId=s.companyId AND t.snapshotDate=s.snapshotDate AND t.periodType=s.periodType
+            WHEN MATCHED THEN UPDATE SET
+                totalOrders=@totOrd, totalRevenue=@totRev, totalRealCost=@totCost,
+                totalMargin=@totMrg, avgMarginPct=@avgMrg, lossOrders=@lossOrd,
+                bestServiceType=@best, worstServiceType=@worst
+            WHEN NOT MATCHED THEN INSERT
+                (companyId,snapshotDate,periodType,totalOrders,totalRevenue,totalRealCost,
+                 totalMargin,avgMarginPct,lossOrders,bestServiceType,worstServiceType)
+            VALUES (@companyId,@snapDate,@periodType,@totOrd,@totRev,@totCost,
+                    @totMrg,@avgMrg,@lossOrd,@best,@worst);
+
+            SELECT '{"message":"snapshot saved"}' AS [jsonResult]
+        END
+
+        ELSE IF @action = 'list'
+        BEGIN
+            SELECT ISNULL(
+                (SELECT TOP (@limitRows)
+                        snapshotId, snapshotDate, periodType, totalOrders,
+                        totalRevenue, totalRealCost, totalMargin, avgMarginPct,
+                        bestServiceType, worstServiceType, lossOrders
+                 FROM [dbo].[profitabilitySnapshots]
+                 WHERE companyId=@companyId AND periodType=@periodType
+                 ORDER BY snapshotDate DESC
+                 FOR JSON PATH, ROOT('snapshots')),
+                '{"snapshots":[]}'
+            ) AS [jsonResult]
+        END
+    END TRY
+    BEGIN CATCH
+        SELECT ('{"error":"' + REPLACE(ERROR_MESSAGE(),'"','\"') + '"}') AS [jsonResult]
+    END CATCH
+END
+GO


### PR DESCRIPTION
SQL (sp_manufacturing.sql):
  tables: machines, productionOrders, utilityRates, maintenanceLogs, profitabilitySnapshots
  SPs: sp_machines, sp_productionOrders, sp_utilityRates, sp_maintenanceLogs, sp_profitabilitySnapshots

Agents (modules/):
  costEngine.py            — real cost = elec+water+det+labor+depreciation+overhead; compute_cycle_cost()
  maintenancePredictor.py  — wear score algo, predict remaining cycles, auto maintenance trigger
  profitabilityOptimizer.py— group margins by cycleType, flag losses, generate suggested prices
  workflowOrchestrator.py  — create/start/complete/cancel orders, ETA queue, single dashboard call
  alertDispatcher.py       — Push+WhatsApp on cycle done, wear alert, low-margin alert, low-supply

Routes: /manufacturing/* (22 endpoints)